### PR TITLE
Improve types of public interface

### DIFF
--- a/missouri/coding.py
+++ b/missouri/coding.py
@@ -118,7 +118,7 @@ class JSONDecoder(MethodListCaller):
         self.register(self.decode)
         self.register(self.decode_numpy)
 
-    def decode(self, obj: JsonType) -> t.Any:
+    def decode(self, obj: t.Any) -> t.Any:
         """
         In a subclass, either override this or add some decode functions and
         override __init__ to register them

--- a/missouri/coding.py
+++ b/missouri/coding.py
@@ -3,7 +3,6 @@
 # Apache 2.0
 
 import typing as t
-from .common_types import JsonType
 from .numpylib import decode_numpy as _decode_numpy, encode_numpy as _encode_numpy
 
 if t.TYPE_CHECKING:  # pragma: no cover
@@ -28,7 +27,7 @@ class MethodListCaller:
         # be defensive if someone forgets to call super pylint: disable=attribute-defined-outside-init
         self.method_list = []
 
-    def __call__(self, obj: t.Any) -> t.Optional[JsonType]:
+    def __call__(self, obj: t.Any) -> t.Any:
         """
         Call the methods in method_list until one of them returns something other than None
         and return that as the result of the call.
@@ -40,7 +39,7 @@ class MethodListCaller:
         except StopIteration:
             return self.default(obj)
 
-    def default(self, x: t.Any) -> t.Optional[JsonType]:
+    def default(self, x: t.Any) -> t.Any:
         """
         If none of the methods returned something, then return this default
         """
@@ -78,17 +77,17 @@ class JSONEncoder(MethodListCaller):
         self.register(self.encode)
         self.register(self.encode_numpy)
 
-    def default(self, obj: t.Any) -> t.Optional[JsonType]:
+    def default(self, obj: t.Any) -> t.Any:
         raise ValueError(f"Object of type {type(obj)} is not JSON-serializable")
 
-    def encode(self, obj: t.Any) -> t.Optional[JsonType]:
+    def encode(self, obj: t.Any) -> t.Any:
         """
         In a subclass, either override this or add some encode functions and
         override __init__ to register them.
         """
         pass
 
-    def encode_numpy(self, obj: "np.ndarray") -> t.Optional[JsonType]:
+    def encode_numpy(self, obj: "np.ndarray") -> t.Any:
         return _encode_numpy(obj, as_primitives=self.encode_as_primitives)
 
 
@@ -119,12 +118,12 @@ class JSONDecoder(MethodListCaller):
         self.register(self.decode)
         self.register(self.decode_numpy)
 
-    def decode(self, obj: JsonType) -> t.Optional[JsonType]:
+    def decode(self, obj: JsonType) -> t.Any:
         """
         In a subclass, either override this or add some decode functions and
         override __init__ to register them
         """
         pass
 
-    def decode_numpy(self, obj: JsonType) -> t.Optional["np.ndarray"]:
+    def decode_numpy(self, obj: t.Any) -> t.Optional["np.ndarray"]:
         return _decode_numpy(obj)

--- a/missouri/common_types.py
+++ b/missouri/common_types.py
@@ -1,4 +1,0 @@
-import typing as t
-
-# Fix this when recursive types are supported.
-JsonType = t.Union[None, int, float, str, bool, t.List[t.Any], t.Dict[str, t.Any]]

--- a/missouri/json.py
+++ b/missouri/json.py
@@ -5,8 +5,7 @@
 import typing as t
 import simplejson as json
 from .coding import JSONDecoder, JSONEncoder
-from .common_types import JsonType
-from .openlib import ensure_text_file_open
+from .openlib import FileLike, ensure_text_file_open
 
 
 def _dump_args(kwargs: dict) -> dict:
@@ -27,7 +26,7 @@ def _dump_args(kwargs: dict) -> dict:
     return kwargs
 
 
-def dump(obj: t.Any, path: str, *args: object, **kwargs: object) -> None:
+def dump(obj: t.Any, path: FileLike, *args: object, **kwargs: object) -> None:
     with ensure_text_file_open(path, "w") as f:
         json.dump(obj, f, *args, **_dump_args(kwargs))
 
@@ -49,10 +48,10 @@ def _load_args(kwargs: dict) -> dict:
     return kwargs
 
 
-def load(path: str, *args: object, **kwargs: object) -> JsonType:
+def load(path: FileLike, *args: object, **kwargs: object) -> t.Any:
     with ensure_text_file_open(path, "r") as f:
         return json.load(f, *args, **_load_args(kwargs))
 
 
-def loads(s: str, **kwargs: object) -> JsonType:
+def loads(s: str, **kwargs: object) -> t.Any:
     return json.loads(s, **_load_args(kwargs))

--- a/missouri/numpylib.py
+++ b/missouri/numpylib.py
@@ -1,7 +1,5 @@
 import typing as t
 
-from .common_types import JsonType
-
 if t.TYPE_CHECKING:  # pragma: no cover
     try:
         import numpy as np
@@ -10,7 +8,7 @@ if t.TYPE_CHECKING:  # pragma: no cover
         pass
 
 
-def encode_numpy(obj: t.Any, as_primitives: bool) -> JsonType:
+def encode_numpy(obj: t.Any, as_primitives: bool) -> t.Any:
     try:
         import numpy as np
     except ImportError:

--- a/missouri/openlib.py
+++ b/missouri/openlib.py
@@ -7,6 +7,7 @@ if t.TYPE_CHECKING:  # pragma: no cover
 
 FileLike = t.Union["FileDescriptorOrPath", t.IO[str]]
 
+
 @contextmanager
 def ensure_text_file_open(
     path_or_fp: t.Union["FileDescriptorOrPath", t.IO[str]], mode: t.Literal["r", "w"]

--- a/missouri/openlib.py
+++ b/missouri/openlib.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 if t.TYPE_CHECKING:  # pragma: no cover
     from _typeshed import FileDescriptorOrPath
 
+FileLike = t.Union["FileDescriptorOrPath", t.IO[str]]
 
 @contextmanager
 def ensure_text_file_open(


### PR DESCRIPTION
This prevents the need to cast the return values, and should allow `json.loads()` to be called on e.g. an AWS request payload.

These are very similar to the types used by simplejson.