### PR TITLE
Clear deprecation warning

### DIFF
--- a/missouri/numpylib.py
+++ b/missouri/numpylib.py
@@ -26,7 +26,7 @@ def encode_numpy(obj: t.Any, as_primitives: bool) -> JsonType:
                 "dtype": obj.dtype.name,
                 "shape": obj.shape,
             }
-    elif isinstance(obj, (np.bool8, np.bool_)):
+    elif isinstance(obj, np.bool_):
         return bool(obj)
     elif isinstance(
         obj,


### PR DESCRIPTION
```
  /Users/pnm/code/missouri/missouri/numpylib.py:27: DeprecationWarning: `np.bool8` is a deprecated alias for `np.bool_`.  (Deprecated NumPy 1.24)
    elif isinstance(obj, (np.bool8, np.bool_)):
```